### PR TITLE
Fix NaN Loss due to Numerical Instability in Quaternion Conversions during MDM training.

### DIFF
--- a/util/torch_util.py
+++ b/util/torch_util.py
@@ -75,7 +75,9 @@ def quat_to_axis_angle(q):
     length = torch.norm(q[..., 0:3], dim=-1, p=2)
     
     angle = 2.0 * torch.atan2(length, q[..., qw])
-    axis = q[..., qx:qw] / length.unsqueeze(-1)
+    # axis = q[..., qx:qw] / length.unsqueeze(-1)
+    safe_length = length.unsqueeze(-1).clamp(min=1e-6)
+    axis = q[..., qx:qw] / safe_length
 
     default_axis = torch.zeros_like(axis)
     default_axis[..., -1] = 1


### PR DESCRIPTION
**Description**
This PR addresses a numerical stability issue in quat_to_axis_angle that caused NaN losses during MDM training.
When the input quaternion length approaches zero, the division axis = q / length could result in NaNs, propagating to velocity and rotation losses and leading to printed loss terms appearing as NaN.

**Changes**
Updated PARC/util/torch_util.py:
Added a clamp to the denominator in quat_to_axis_angle to prevent division by near-zero values.
Ensures safe_length has a minimum value of 1e-6.

**Impact**
Eliminates NaN values in training loss during MDM training.