### PR TITLE
Fix the bug of checkpoint saving induced by path formatting.

### DIFF
--- a/diffusion/mdm.py
+++ b/diffusion/mdm.py
@@ -1326,7 +1326,7 @@ class MDM(MotionGenerator):
 
             if not test_only:
                 if epoch % self._epochs_per_checkpoint == 0 and epoch > 0 and checkpoint_dir is not None:
-                    checkpoint_save_path = checkpoint_dir + "model_" + str(epoch) + ".pkl"
+                    checkpoint_save_path = checkpoint_dir / ("model_" + str(epoch) + ".pkl")
                     self.save(checkpoint_save_path)
 
         self._denoise_model.eval()


### PR DESCRIPTION
**Description**
When saving the checkpoint, encountered error message: TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str'. 
Here, the checkpoint dir is a pathlib.Path object (PosixPath on Linux). The Path object does not support direct concatenation of strings using the plus sign +.

**Change**
Updated checkpoint saving line in PARC/diffusion/mdm.py

**Impact**
The checkpoint can be saved successfully after the change.