### PR TITLE
Fix tracker config generation to avoid invalid "None" in_model_file path loading.

### DIFF
--- a/parc_0_setup_iter.py
+++ b/parc_0_setup_iter.py
@@ -126,7 +126,11 @@ for i in range(kin_gen_num_batches_of_motions):
 
 print("********** CREATING PARC 3 TRACKER CONFIGS **********")
 tracker_config = yaml.safe_load(input_tracker_config_path.open('r'))
-tracker_config["in_model_file"] = str(input_tracker_model_path)
+if input_tracker_model_path is not None:
+    tracker_config["in_model_file"] = str(input_tracker_model_path)
+else:
+    tracker_config["in_model_file"] = None
+
 tracker_config["output_dir"] = str(output_tracker_dir)
 
 tracker_dataset_path = output_tracker_dir / "motions.yaml"


### PR DESCRIPTION
**Description**
This PR fixes an issue in the iteration setup script (`parc_0_setup_iter.py`) where the in_model_file configuration parameter for `parc_3_tracker.py ` was being incorrectly serialized as the string "None" when no initial model path was provided.
**Problem**
Previously, `str(input_tracker_model_path) `was called unconditionally. When `input_tracker_model_path` was None (default for the first iteration), this resulted in `in_model_file: None` in the generated YAML config.
This caused the downstream tracker training script to fail with the following error, as it attempted to load a file literally named 

"None":
`File "parc_3_tracker.py", line 77, in train_tracker
  run.main(train_argv.split())
File "/home/phi/CLX/projects/humanoid_loco/PARC/run.py", line 121, in run
  agent.load(model_file)
...
File "/home/phi/CLX/projects/humanoid_loco/PARC/learning/base_agent.py", line 135, in load
  state_dict = torch.load(in_file, map_location=self._device)
...
FileNotFoundError: [Errno 2] No such file or directory: 'None'`

**Fix**
Modified `parc_0_setup_iter.py` to check if` input_tracker_model_path` is None before string conversion.
If None, the configuration value is explicitly set to None (which serializes to YAML null).
This ensures the training script correctly identifies that no pre-trained model should be loaded, preventing the FileNotFoundError.